### PR TITLE
fixed issue with datetime retuning 1 hour out.

### DIFF
--- a/firetail/auditor.py
+++ b/firetail/auditor.py
@@ -1,4 +1,4 @@
-import datetime
+import time
 import hashlib
 import json
 import logging
@@ -138,7 +138,7 @@ class cloud_logger(object):
             failed_res_body = True
         payload = {
             "version": "1.1",
-            "dateCreated": int((datetime.datetime.utcnow()).timestamp() * 1000),
+            "dateCreated": int(time.time() * 1000),
             "execution_time": diff,
             "source_code": sys.version,
             "req": {


### PR DESCRIPTION
changed datetime.datetime.utcnow()).timestamp()  to use time.time()

Fixes # .
issue with datetime being 1 hour out on utc