### PR TITLE
Hotfix adding duplicating handlers registered to loggers

### DIFF
--- a/firetail/logger.py
+++ b/firetail/logger.py
@@ -1,5 +1,9 @@
 import logging
 import sys
+from threading import Lock
+
+logger_names_with_handlers_lock = Lock()
+logger_names_with_handlers = set()
 
 
 def get_logger(debug):
@@ -14,7 +18,12 @@ def get_stdout_logger(debug):
 
 def __get_logger(debug, name, handler=None):
     logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG if debug else logging.INFO)
-    if handler:
-        logger.addHandler(handler)
+
+    with logger_names_with_handlers_lock:
+        if name not in logger_names_with_handlers:
+            logger.setLevel(logging.DEBUG if debug else logging.INFO)
+            if handler:
+                logger.addHandler(handler)
+            logger_names_with_handlers.add(name)
+
     return logger

--- a/firetail/logger.py
+++ b/firetail/logger.py
@@ -2,28 +2,23 @@ import logging
 import sys
 from threading import Lock
 
-logger_names_with_handlers_lock = Lock()
-logger_names_with_handlers = set()
-
-
-def get_logger(debug):
-    return __get_logger(debug, __name__)
+configured_loggers_lock = Lock()
+configured_loggers = set()
 
 
 def get_stdout_logger(debug):
-    stdout_logger = __get_logger(debug, __name__ + "_stdout", logging.StreamHandler(sys.stdout))
-    stdout_logger.propagate = False
+    stdout_logger_name = __name__ + "_stdout"
+    stdout_logger = logging.getLogger(stdout_logger_name)
+
+    requires_config = False
+    with configured_loggers_lock:
+        if stdout_logger_name not in configured_loggers:
+            configured_loggers.add(stdout_logger_name)
+            requires_config = True
+
+    if requires_config:
+        stdout_logger.propagate = False
+        stdout_logger.setLevel(logging.DEBUG if debug else logging.INFO)
+        stdout_logger.addHandler(logging.StreamHandler(sys.stdout))
+
     return stdout_logger
-
-
-def __get_logger(debug, name, handler=None):
-    logger = logging.getLogger(name)
-
-    with logger_names_with_handlers_lock:
-        if name not in logger_names_with_handlers:
-            logger.setLevel(logging.DEBUG if debug else logging.INFO)
-            if handler:
-                logger.addHandler(handler)
-            logger_names_with_handlers.add(name)
-
-    return logger

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,10 @@ PyYAML==6.0.1
 requests==2.31.0
 starlette==0.27.0
 werkzeug==2.2.3
+swagger-ui-bundle==0.0.9
 aiohttp_jinja2
 aiohttp
 aiohttp_remotes
 pytest-aiohttp
 starlette
 a2wsgi
-swagger-ui-bundle


### PR DESCRIPTION
Every time `get_stdout_logger` was called, the `.addHandler` method of the logger named `__name__ + "_stdout"` was called with another `logging.StreamHandler` instance.

This hotfix just remembers which loggers have been configured by name in a set, which is mutexed with a `threading.Lock`.

Also pins swagger-ui-bundle to 0.0.9 as there appears to be incompatibility with 1.1.0, released Nov 1st.