### PR TITLE
Missing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ aiohttp_remotes
 pytest-aiohttp
 starlette
 a2wsgi
+packaging

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
 swagger_ui_require = "swagger-ui-bundle>=0.0.2,<0.1"
 
 flask_require = [
-    "flask[async]>=2.2.5,<3.0",
+    "flask[async]==2.2.5",
     "a2wsgi>=1.4,<2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ install_requires = [
     "inflection>=0.3.1,<0.6",
     "werkzeug>=2.2.2,<3",
     "starlette>=0.27,<1",
+    "packaging>=23.2",
 ]
 
 swagger_ui_require = "swagger-ui-bundle>=0.0.2,<0.1"


### PR DESCRIPTION
Upon installing the lib in a fresh env, I could not run the example at `examples/openapi3/helloworld/hello.py` due to two issues:

1. [`packaging`](https://pypi.org/project/packaging/) appears to be missing from the requirements, resulting in a `ModuleNotFoundError: No module named 'packaging'`
2. The library is not currently compatible with Flask >2.2.5; currently 2.3.3 is installed. This results in a `AttributeError: module 'flask.json' has no attribute 'JSONEncoder'`. Support for Flask >2.2.5 is in progress at #32.