### PR TITLE
we need to pass flask app options into the blueprint registration

### DIFF
--- a/firetail/apps/flask_app.py
+++ b/firetail/apps/flask_app.py
@@ -77,7 +77,7 @@ class FlaskApp(AbstractApp):
 
     def add_api(self, specification, **kwargs):
         api = super().add_api(specification, **kwargs)
-        self.app.register_blueprint(api.blueprint)
+        self.app.register_blueprint(api.blueprint, **kwargs.get('options', {}))
         if isinstance(specification, (str, pathlib.Path)):
             self.extra_files.append(self.specification_dir / specification)
         return api


### PR DESCRIPTION
This takes an options param:
https://github.com/pallets/flask/blob/4df377cfbfc1d15e962a61c18920b22aebc9aa41/src/flask/sansio/app.py#L574

Which we need to set the app name, as seen here:
https://github.com/pallets/flask/blob/4df377cfbfc1d15e962a61c18920b22aebc9aa41/src/flask/sansio/blueprints.py#L304

This will allow us to call `add_api` multiple times and so registering different APIs with different conditions enabled (eg - enabling response validation for a subset of apis).