### PR TITLE
add accessToken support

### DIFF
--- a/firetail/security/security_handler_factory.py
+++ b/firetail/security/security_handler_factory.py
@@ -182,12 +182,14 @@ class AbstractSecurityHandlerFactory(abc.ABC):
             raise OAuthProblem(description="Invalid authorization header")
         return auth_type.lower(), value
 
+    BEARER_AUTH_TYPES = {"bearer", "accesstoken", "access_token"}
+
     def verify_oauth(self, token_info_func, scope_validate_func, required_scopes):
         check_oauth_func = self.check_oauth_func(token_info_func, scope_validate_func)
 
         def wrapper(request):
             auth_type, token = self.get_auth_header_value(request)
-            if auth_type != "bearer":
+            if auth_type not in self.BEARER_AUTH_TYPES:
                 return self.no_value
 
             return check_oauth_func(request, token, required_scopes=required_scopes)
@@ -273,7 +275,7 @@ class AbstractSecurityHandlerFactory(abc.ABC):
 
         def wrapper(request):
             auth_type, token = self.get_auth_header_value(request)
-            if auth_type != "bearer":
+            if auth_type not in self.BEARER_AUTH_TYPES:
                 return self.no_value
             return check_bearer_func(request, token)
 


### PR DESCRIPTION
This pull request updates the OAuth and Bearer authentication logic in `security_handler_factory.py` to support additional authorization header types. The main change is allowing tokens with `accesstoken` and `access_token` types, in addition to the standard `bearer` type, improving compatibility with various clients.

**Authentication header support improvements:**

* Added a `BEARER_AUTH_TYPES` set to support multiple recognized authorization header types: `bearer`, `accesstoken`, and `access_token` in the authentication flow.
* Updated both the `verify_oauth` and `verify_bearer` methods to check if the authorization type is in `BEARER_AUTH_TYPES`, instead of only accepting `bearer`. [[1]](diffhunk://#diff-c8cb29c155352cf30376e2092eb7cc85d05d1b3ea522f3553c4c93eaa08bd4fbR185-R192) [[2]](diffhunk://#diff-c8cb29c155352cf30376e2092eb7cc85d05d1b3ea522f3553c4c93eaa08bd4fbL276-R278)